### PR TITLE
Add contributor guidelines file and start discussion around dao-kit contribution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing to Aragon DAO Kits and Templates
+
+:tada: Thank you for being interested in contributing to an Aragon Project! :tada:
+
+The following is a set of guidelines and helpful pointers for contributing to Aragon DAO kits. The keyword here is *guidelines*, not rules. As such, use your best judgement and feel free to propose changes to even this document.
+
+## Code of Conduct
+
+Everyone participating in this project is governed by the [Aragon Code of Conduct](http://wiki.aragon.one/documentation/Code_of_Conduct/). By participating, you are expected to uphold this code as well.
+
+Please report unacceptable behavior to a maintainer through either Twitter or by shooting us an e-mail at contact [at] aragon.one.
+
+## I Just Have A Question
+
+Please don't file an issue with questions. It's easier for you and for us if you go directly to [our chat](https://aragon.chat), since it will keep our repositories clean and you will get a faster response.


### PR DESCRIPTION
Meets requirements for #12 with boilerplate contribution file.

Also, I wanted to spark up a discussion around contribution to the dao-kits monorepo based on my initial experience. I know there are a lot of advancements slated for this repo (eg TCR, Payroll, and the BareKit) but I had two primary pain points as an external contributor that I wanted to mention. 

The good news is that I'm interested in lending a hand to solve those issues for future contributors :)

**Pain Point 1: Limited documentation**
There is great power in kits and templates but I found it challenging to understand the future direction which makes thinking through documentation (like contribution guidelines) a little challenging. With upcoming improvements, specifically BareKit, I would love to understand how we envision the evolution of kits. 

Honestly, I think this could be as easy as updated the README and maybe a short blog post or wiki entry. I think this would allow potential contributors to really conceptualize the power, flexibility, and importance of kits/templates in the system.

**Pain Point 2: Kit code security & audit processes**
Modification to kit code will be scrutinized (potentially more than other areas) and would love to learn more about the form this will take in the near term. It's mentioned that once available, all mainnet-ready kits will leverage a `security.md` file that essentially flags potential issues/concerns that deviate from a best practice approach. I see the value in adding a lightweight version of that for all kits. Would be great to also get some form minimal integration test (even now, if not done already)

To sum up, I'm interested in learning more about the future development of dao-kits and determining what quick, high value add improvements could be done to make this repo more friendly to outside contributors. 