### PR TITLE
SurveyKit: modernize

### DIFF
--- a/kits/survey/contracts/SurveyKit.sol
+++ b/kits/survey/contracts/SurveyKit.sol
@@ -4,6 +4,7 @@ import "@aragon/os/contracts/apm/APMNamehash.sol";
 import "@aragon/os/contracts/apm/Repo.sol";
 import "@aragon/os/contracts/factory/DAOFactory.sol";
 import "@aragon/os/contracts/kernel/Kernel.sol";
+import "@aragon/os/contracts/kernel/KernelConstants.sol";
 import "@aragon/os/contracts/acl/ACL.sol";
 import "@aragon/apps-shared-minime/contracts/MiniMeToken.sol";
 import "@aragon/os/contracts/lib/ens/ENS.sol";
@@ -14,11 +15,12 @@ import "@aragon/apps-survey/contracts/Survey.sol";
 import "@aragon/kits-base/contracts/KitBase.sol";
 
 
-contract SurveyKit is APMNamehash, KitBase {
+contract SurveyKit is /* APMNamehash, */ KernelAppIds, KitBase {
     ENS public ens;
     DAOFactory public fac;
 
-    bytes32 constant public SURVEY_APP_ID = apmNamehash("survey"); // survey.aragonpm.eth
+    // bytes32 constant public SURVEY_APP_ID = apmNamehash("survey"); // survey.aragonpm.eth
+    bytes32 constant public SURVEY_APP_ID = 0x030b2ab880b88e228f2da5a3d19a2a31bc10dbf91fb1143776a6de489389471e; // survey.aragonpm.eth
 
     event DeployInstance(address dao, address indexed token);
 
@@ -32,7 +34,7 @@ contract SurveyKit is APMNamehash, KitBase {
         address surveyManager,
         address escapeHatch,
         uint64 duration,
-        uint256 participation
+        uint64 participation
     )
         public
         returns (Kernel, Survey)
@@ -45,7 +47,7 @@ contract SurveyKit is APMNamehash, KitBase {
         Survey survey = Survey(dao.newAppInstance(SURVEY_APP_ID, latestVersionAppBase(SURVEY_APP_ID)));
 
         // Set escapeHatch address as the default vault, in case a token rescue is required
-        dao.setApp(dao.APP_BASES_NAMESPACE(), dao.DEFAULT_VAULT_APP_ID(), escapeHatch);
+        dao.setApp(dao.APP_BASES_NAMESPACE(), KERNEL_DEFAULT_VAULT_APP_ID, escapeHatch);
 
         survey.initialize(signalingToken, participation, duration);
 

--- a/kits/survey/contracts/SurveyKit.sol
+++ b/kits/survey/contracts/SurveyKit.sol
@@ -30,6 +30,7 @@ contract SurveyKit is /* APMNamehash, */ KernelAppIds, KitBase {
     function newInstance(
         MiniMeToken signalingToken,
         address surveyManager,
+        address escapeHatchOwner,
         uint64 duration,
         uint64 participation
     )
@@ -52,7 +53,7 @@ contract SurveyKit is /* APMNamehash, */ KernelAppIds, KitBase {
         // surveyManager can then give this permission to other entities
         acl.createPermission(surveyManager, survey, survey.CREATE_SURVEYS_ROLE(), surveyManager);
         acl.createPermission(surveyManager, survey, survey.MODIFY_PARTICIPATION_ROLE(), surveyManager);
-        acl.createPermission(surveyManager, vault, vault.TRANSFER_ROLE(), surveyManager);
+        acl.createPermission(escapeHatchOwner, vault, vault.TRANSFER_ROLE(), escapeHatchOwner);
 
         cleanupDAOPermissions(dao, acl, surveyManager);
 

--- a/kits/survey/contracts/SurveyKit.sol
+++ b/kits/survey/contracts/SurveyKit.sol
@@ -11,6 +11,7 @@ import "@aragon/os/contracts/lib/ens/ENS.sol";
 import "@aragon/os/contracts/lib/ens/PublicResolver.sol";
 
 import "@aragon/apps-survey/contracts/Survey.sol";
+import "@aragon/apps-vault/contracts/Vault.sol";
 
 import "@aragon/kits-base/contracts/KitBase.sol";
 
@@ -43,10 +44,15 @@ contract SurveyKit is /* APMNamehash, */ KernelAppIds, KitBase {
         Survey survey = Survey(dao.newAppInstance(SURVEY_APP_ID, latestVersionAppBase(SURVEY_APP_ID)));
         survey.initialize(signalingToken, participation, duration);
 
+        // Install a vault to let it be the escape hatch
+        Vault vault = Vault(dao.newAppInstance(KERNEL_DEFAULT_VAULT_APP_ID, latestVersionAppBase(KERNEL_DEFAULT_VAULT_APP_ID)));
+        vault.initialize();
+
         // Set survey manager as the entity that can create votes and change participation
         // surveyManager can then give this permission to other entities
         acl.createPermission(surveyManager, survey, survey.CREATE_SURVEYS_ROLE(), surveyManager);
         acl.createPermission(surveyManager, survey, survey.MODIFY_PARTICIPATION_ROLE(), surveyManager);
+        acl.createPermission(surveyManager, vault, vault.TRANSFER_ROLE(), surveyManager);
         acl.grantPermission(surveyManager, dao, dao.APP_MANAGER_ROLE());
         acl.setPermissionManager(surveyManager, dao, dao.APP_MANAGER_ROLE());
 

--- a/kits/survey/contracts/SurveyKit.sol
+++ b/kits/survey/contracts/SurveyKit.sol
@@ -16,9 +16,6 @@ import "@aragon/kits-base/contracts/KitBase.sol";
 
 
 contract SurveyKit is /* APMNamehash, */ KernelAppIds, KitBase {
-    ENS public ens;
-    DAOFactory public fac;
-
     // bytes32 constant public SURVEY_APP_ID = apmNamehash("survey"); // survey.aragonpm.eth
     bytes32 constant public SURVEY_APP_ID = 0x030b2ab880b88e228f2da5a3d19a2a31bc10dbf91fb1143776a6de489389471e; // survey.aragonpm.eth
 
@@ -32,7 +29,6 @@ contract SurveyKit is /* APMNamehash, */ KernelAppIds, KitBase {
     function newInstance(
         MiniMeToken signalingToken,
         address surveyManager,
-        address escapeHatch,
         uint64 duration,
         uint64 participation
     )
@@ -45,10 +41,6 @@ contract SurveyKit is /* APMNamehash, */ KernelAppIds, KitBase {
         acl.createPermission(this, dao, dao.APP_MANAGER_ROLE(), this);
 
         Survey survey = Survey(dao.newAppInstance(SURVEY_APP_ID, latestVersionAppBase(SURVEY_APP_ID)));
-
-        // Set escapeHatch address as the default vault, in case a token rescue is required
-        dao.setApp(dao.APP_BASES_NAMESPACE(), KERNEL_DEFAULT_VAULT_APP_ID, escapeHatch);
-
         survey.initialize(signalingToken, participation, duration);
 
         // Set survey manager as the entity that can create votes and change participation

--- a/kits/survey/contracts/SurveyKit.sol
+++ b/kits/survey/contracts/SurveyKit.sol
@@ -53,7 +53,6 @@ contract SurveyKit is /* APMNamehash, */ KernelAppIds, KitBase {
         acl.createPermission(surveyManager, survey, survey.CREATE_SURVEYS_ROLE(), surveyManager);
         acl.createPermission(surveyManager, survey, survey.MODIFY_PARTICIPATION_ROLE(), surveyManager);
         acl.createPermission(surveyManager, vault, vault.TRANSFER_ROLE(), surveyManager);
-        acl.grantPermission(surveyManager, dao, dao.APP_MANAGER_ROLE());
 
         cleanupDAOPermissions(dao, acl, surveyManager);
 

--- a/kits/survey/contracts/SurveyKit.sol
+++ b/kits/survey/contracts/SurveyKit.sol
@@ -54,7 +54,6 @@ contract SurveyKit is /* APMNamehash, */ KernelAppIds, KitBase {
         acl.createPermission(surveyManager, survey, survey.MODIFY_PARTICIPATION_ROLE(), surveyManager);
         acl.createPermission(surveyManager, vault, vault.TRANSFER_ROLE(), surveyManager);
         acl.grantPermission(surveyManager, dao, dao.APP_MANAGER_ROLE());
-        acl.setPermissionManager(surveyManager, dao, dao.APP_MANAGER_ROLE());
 
         cleanupDAOPermissions(dao, acl, surveyManager);
 

--- a/kits/survey/package.json
+++ b/kits/survey/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@aragon/apps-shared-minime": "^1.0.0",
-    "@aragon/apps-survey": "^1.0.0-rc.2",
+    "@aragon/apps-survey": "^1.0.0-rc.3",
     "@aragon/apps-vault": "^4.0.0",
     "@aragon/os": "^4.1.0-rc.1",
     "@aragon/kits-base": "^1.0.0"

--- a/kits/survey/package.json
+++ b/kits/survey/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@aragon/apps-shared-minime": "^1.0.0",
-    "@aragon/apps-survey": "^1.0.0-beta.1",
-    "@aragon/os": "4.0.0-beta.3",
+    "@aragon/apps-survey": "^1.0.0-rc.2",
+    "@aragon/os": "^4.1.0-rc.1",
     "@aragon/kits-base": "^1.0.0"
   }
 }

--- a/kits/survey/package.json
+++ b/kits/survey/package.json
@@ -20,7 +20,7 @@
     "@aragon/apps-shared-minime": "^1.0.0",
     "@aragon/apps-survey": "^1.0.0-rc.3",
     "@aragon/apps-vault": "^4.0.0",
-    "@aragon/os": "^4.1.0-rc.1",
+    "@aragon/os": "^4.1.0",
     "@aragon/kits-base": "^1.0.0"
   }
 }

--- a/kits/survey/package.json
+++ b/kits/survey/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@aragon/apps-shared-minime": "^1.0.0",
     "@aragon/apps-survey": "^1.0.0-rc.2",
+    "@aragon/apps-vault": "^4.0.0",
     "@aragon/os": "^4.1.0-rc.1",
     "@aragon/kits-base": "^1.0.0"
   }

--- a/kits/survey/scripts/deploy.js
+++ b/kits/survey/scripts/deploy.js
@@ -26,8 +26,11 @@ module.exports = async (callback) => {
 
   console.log('Deploying Survey Kit')
 
-  const ens = ENS.at(process.env.ENS || '0x644f11d76d4b192df168c49a06db4928ea410bbc')
   const owner = process.env.OWNER
+  const ens = ENS.at(
+    process.env.ENS ||
+    '0x5f6f7e8cc7346a11ca2def8f827b7a0b612c56a1' // aragen's default ENS
+  )
 
   console.log('ENS', ens.address)
   console.log('Owner', owner)

--- a/kits/survey/scripts/launch_demo.js
+++ b/kits/survey/scripts/launch_demo.js
@@ -29,10 +29,10 @@ const accounts = [
 ]
 
 // Survey params
-const SURVEY_DURATION = 60 * 60 * 16 // 24 hours
-const SURVEY_PARTICIPATION = pct16(10) // 10%
-const SURVEY_CHART_BLOCKS = 16 // front-end chart blocks
 const TOKEN_BASE_DECIMAL = 1e18
+const SURVEY_CHART_BLOCKS = 16 // front-end chart blocks
+const SURVEY_DURATION = 60 * 60 * SURVEY_CHART_BLOCKS // one hour for each block
+const SURVEY_PARTICIPATION = pct16(10) // 10%
 
 module.exports = async (callback) => {
   console.log('Launching Survey demo')

--- a/kits/survey/scripts/launch_demo.js
+++ b/kits/survey/scripts/launch_demo.js
@@ -97,7 +97,7 @@ module.exports = async (callback) => {
 
   // Create DAO with just Survey installed
   console.log('Creating Survey DAO...')
-  const surveyDaoReceipt = await surveyKit.newInstance(surveyToken.address, owner, SURVEY_DURATION, SURVEY_PARTICIPATION)
+  const surveyDaoReceipt = await surveyKit.newInstance(surveyToken.address, owner, owner, SURVEY_DURATION, SURVEY_PARTICIPATION)
   const surveyDaoAddr = createdSurveyDao(surveyDaoReceipt)
   const surveyAppAddr = installedApp(surveyDaoReceipt, surveyAppId)
 

--- a/kits/survey/scripts/launch_demo.js
+++ b/kits/survey/scripts/launch_demo.js
@@ -1,0 +1,239 @@
+const path = require('path')
+const fs = require('fs')
+
+const namehash = require('eth-ens-namehash').hash
+
+const ENS = artifacts.require('@aragon/os/contracts/lib/ens/ENS')
+const MiniMeToken = artifacts.require('@aragon/os/contracts/lib/minime/MiniMeToken')
+const MiniMeTokenFactory = artifacts.require('@aragon/os/contracts/lib/minime/MiniMeTokenFactory')
+const PublicResolver = artifacts.require('@aragon/os/contracts/lib/ens/PublicResolver')
+const Repo = artifacts.require('@aragon/os/contracts/apm/Repo')
+
+const SurveyKit = artifacts.require('@aragon/kits-survey/contracts/SurveyKit')
+const Survey = artifacts.require('@aragon/apps-survey/contracts/Survey')
+
+// Utils
+const surveyAppId = namehash('survey.aragonpm.eth')
+const surveyKitEnsNode = namehash('survey-kit.aragonpm.eth')
+const pct16 = x => new web3.BigNumber(x).times(new web3.BigNumber(10).toPower(16))
+const createdSurveyDao = receipt => receipt.logs.filter(x => x.event == 'DeployInstance')[0].args.dao
+const createdSurveyId = receipt => receipt.logs.filter(x => x.event == 'StartSurvey')[0].args.surveyId
+const installedApp = (receipt, appId) => receipt.logs.filter(x => x.event == 'InstalledApp' && x.args.appId === appId)[0].args.appProxy
+
+// Survey params
+const SURVEY_DURATION = 60 * 60 * 16 // 24 hours
+const SURVEY_PARTICIPATION = pct16(10) // 10%
+const SURVEY_CHART_BLOCKS = 16 // front-end chart blocks
+const TOKEN_BASE_DECIMAL = 1e18
+
+module.exports = async (callback, accounts) => {
+  console.log('Launching Survey demo')
+
+  if (process.argv.length < 5 || process.argv[3] != '--network') {
+    console.error('Usage: truffle exec --network <network> scripts/launch-demo.js')
+    exit(1)
+  }
+  const network = process.argv[4]
+
+  const owner = process.env.OWNER
+  const ens = ENS.at(
+    process.env.ENS ||
+    '0x5f6f7e8cc7346a11ca2def8f827b7a0b612c56a1' // aragen's default ENS
+  )
+
+  console.log('ENS', ens.address)
+  console.log('Owner', owner)
+
+  const surveyKitRepo = Repo.at(
+    await PublicResolver.at(
+      await ens.resolver(surveyKitEnsNode)
+    ).addr(surveyKitEnsNode)
+  )
+  // Contract address is second return of Repo.getLatest()
+  const surveyKit = SurveyKit.at((await surveyKitRepo.getLatest())[1])
+  console.log('SurveyKit:', kit.address)
+
+  // Create minime token and assign to accounts
+  const minimeFac = await MiniMeTokenFactory.new()
+  const surveyToken = await MiniMeToken.new(
+    minimeFac.address,
+    '0x00',
+    '0x00',
+    'Demo Survey',
+    18,
+    'SUR',
+    true
+  )
+
+  // Total of 30 tokens being assigned
+  const tokenAssignments = [
+    TOKEN_BASE_DECIMAL * 16,
+    TOKEN_BASE_DECIMAL * 8,
+    TOKEN_BASE_DECIMAL * 4,
+    TOKEN_BASE_DECIMAL * 2
+  ]
+  await Promise.all(
+    tokenAssignments.map((amount, i) => {
+      const account = accounts[i]
+      console.log(`Assigned ${account} ${amount} tokens`)
+      return surveyToken.generateTokens(accounts[i], amount)
+    })
+  )
+
+  // Create DAO with just Survey installed
+  console.log('Creating Survey DAO...')
+  const surveyDaoReceipt = await surveyKit.newInstance(surveyToken.address, root, '0x00', SURVEY_DURATION, SURVEY_PARTICIPATION)
+  const surveyDaoAddr = createdSurveyDao(surveyDaoReceipt)
+  const surveyAppAddr = installedApp(surveyDaoReceipt, surveyAppId)
+
+  // Create some sample surveys and vote on them
+  const survey = Survey.at(surveyAppAddr)
+
+  const newSurvey = ({ question, description, options, url }) => {
+    const metadata = {
+      specId: namehash('1.metadata.survey.aragonpm.eth'),
+      metadata: {
+        question,
+        description,
+        options,
+        url,
+      }
+    }
+    return survey.newSurvey(JSON.stringify(metadata), options.length)
+  }
+  const voteSurvey = (surveyId, { options, stakes }, txOptions) => {
+    return survey.voteOptions(surveyId, options, stakes, txOptions)
+  }
+
+  // Start some surveys
+  console.log('Creating some surveys...')
+  const surveyMetadata = [
+    {
+      question: 'Should we get Carlos Matos?',
+      description: 'Coming to an event near you!',
+      options: ['OMG YES', ':sigh:', "You're telling me, he's real???"],
+      url: 'https://github.com/aragon/nest/issues/4',
+    },
+    {
+      question: 'When should the Aragon Network be launched?',
+      description: 'The Aragon Network is an upcoming launch by the Aragon team!',
+      options: ['Q1 2019', 'Q2 2019', 'Q3 2019', 'Q4 2019', 'Soon'],
+      url: 'https://github.com/aragon/nest/issues/1',
+    },
+    {
+      question: 'What should we name our 0.6 release?',
+      description: 'We want your help in naming it!',
+      options: ['Buidler', 'Engineer', 'Artist', 'Infinity'],
+      url: 'https://github.com/aragon/nest/issues/3',
+    },
+    {
+      question: 'Should ANT be redeployed as an ERC-777 token?',
+      description: 'The current ANT token is a MiniMe token, but this is costly in gas for most users.',
+      options: ['Yes', 'No'],
+      url: 'https://github.com/aragon/nest/issues/2',
+    },
+  ]
+  const surveys = await Promise.all(
+    surveyMetadata.map(
+      metadata => newSurvey(metadata)
+        .then(receipt => ({
+          metadata,
+          id: receipt.logs.filter(x => x.event === 'StartSurvey')[0].args.surveyId,
+        }))
+    )
+  )
+
+  // Vote on the surveys—each account will vote for a few options at a specific
+  // point in time (to make them show up in different time buckets in the UI)
+  // REMEMBER: optionIds start from 1, not 0!
+  console.log('Voting on the surveys...')
+  const account1Votes = [
+    {
+      options: [2],
+      stakes: [TOKEN_BASE_DECIMAL * 2],
+    },
+    {
+      options: [5],
+      stakes: [TOKEN_BASE_DECIMAL * 5],
+    },
+    {
+      options: [1, 3],
+      stakes: [TOKEN_BASE_DECIMAL * 8, TOKEN_BASE_DECIMAL * 3],
+    },
+  ]
+  await Promise.all(
+    account1Votes.map(
+      (voteParams, index) => voteSurvey(surveys[index].id, voteParams, { from: accounts[0] })
+    )
+  )
+  // Haha, this time travel idea doesn't actually work
+  // await timeTravel(SURVEY_DURATION / SURVEY_CHART_BLOCKS + 1)
+
+  const account2Votes = [
+    {
+      options: [1],
+      stakes: [TOKEN_BASE_DECIMAL * 1],
+    },
+    {
+      options: [1, 2],
+      stakes: [TOKEN_BASE_DECIMAL * 1, TOKEN_BASE_DECIMAL * 1],
+    },
+    {
+      options: [2],
+      stakes: [TOKEN_BASE_DECIMAL * 1],
+    },
+  ]
+  await Promise.all(
+    account2Votes.map(
+      (voteParams, index) => voteSurvey(surveys[index].id, voteParams, { from: accounts[1] })
+    )
+  )
+  // await timeTravel(SURVEY_DURATION / SURVEY_CHART_BLOCKS + 1)
+
+  const account3Votes = [
+    {
+      options: [2],
+      stakes: [TOKEN_BASE_DECIMAL * 4],
+    },
+    {
+      options: [3, 4],
+      stakes: [TOKEN_BASE_DECIMAL * 2, TOKEN_BASE_DECIMAL * 1],
+    },
+    {
+      options: [2],
+      stakes: [TOKEN_BASE_DECIMAL * 1],
+    },
+  ]
+  await Promise.all(
+    account3Votes.map(
+      (voteParams, index) => voteSurvey(surveys[index].id, voteParams, { from: accounts[2] })
+    )
+  )
+  // await timeTravel(SURVEY_DURATION / SURVEY_CHART_BLOCKS + 1)
+
+  const account4Votes = [
+    {
+      options: [1],
+      stakes: [TOKEN_BASE_DECIMAL * 1],
+    },
+    {
+      options: [1],
+      stakes: [TOKEN_BASE_DECIMAL * 1],
+    },
+    {
+      options: [1],
+      stakes: [TOKEN_BASE_DECIMAL * 1],
+    },
+  ]
+  await Promise.all(
+    account4Votes.map(
+      (voteParams, index) => voteSurvey(surveys[index].id, voteParams, { from: accounts[3] })
+    )
+  )
+
+  console.log('===========')
+  console.log('Survey demo DAO set up!')
+  console.log('Survey DAO:', surveyDaoAddr)
+  console.log("Survey DAO's Survey app:", surveyAppAddr)
+  console.log('Survey Token:', surveyToken.address)
+}


### PR DESCRIPTION
Also includes:

- Some contract fixes for the kit
- Installs a Vault instance as the escape hatch (we have to set a contract as the escape hatch)
- Demo launch script, for easy local testing

TODO:

- [ ] Update Survey dependency once republished, and then retest