### PR TITLE
test-token-deployer: minimize dependencies and mark contracts as unmaintained

### DIFF
--- a/helpers/test-token-deployer/contracts/Depositer.sol
+++ b/helpers/test-token-deployer/contracts/Depositer.sol
@@ -1,7 +1,7 @@
 pragma solidity 0.4.18;
 
+import "./IFinance.sol";
 import "./TokenFactory.sol";
-import "@aragon/apps-finance/contracts/Finance.sol";
 
 
 contract Depositer {
@@ -11,7 +11,7 @@ contract Depositer {
         factory = _factory;
     }
 
-    function pleaseAirdrop(Finance finance, Token token, uint256 many, string why) {
+    function pleaseAirdrop(IFinance finance, Token token, uint256 many, string why) {
         factory.mint(token, this, many);
         token.approve(finance, many);
         finance.deposit(token, many, why);

--- a/helpers/test-token-deployer/contracts/IFinance.sol
+++ b/helpers/test-token-deployer/contracts/IFinance.sol
@@ -1,0 +1,8 @@
+pragma solidity 0.4.18;
+
+import "./token/ERC20.sol";
+
+
+interface IFinance {
+    function deposit(ERC20 token, uint256 amount, string why) public;
+}

--- a/helpers/test-token-deployer/contracts/MintableToken.sol
+++ b/helpers/test-token-deployer/contracts/MintableToken.sol
@@ -1,6 +1,6 @@
 pragma solidity 0.4.18;
 
-import "@aragon/os/contracts/lib/zeppelin/token/StandardToken.sol";
+import "./token/StandardToken.sol";
 
 /**
  * @title Ownable

--- a/helpers/test-token-deployer/contracts/math/SafeMath.sol
+++ b/helpers/test-token-deployer/contracts/math/SafeMath.sol
@@ -1,0 +1,32 @@
+pragma solidity ^0.4.11;
+
+
+/**
+ * @title SafeMath
+ * @dev Math operations with safety checks that throw on error
+ */
+library SafeMath {
+  function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+    uint256 c = a * b;
+    require(a == 0 || c / a == b);
+    return c;
+  }
+
+  function div(uint256 a, uint256 b) internal pure returns (uint256) {
+    // assert(b > 0); // Solidity automatically throws when dividing by 0
+    uint256 c = a / b;
+    // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+    return c;
+  }
+
+  function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+    require(b <= a);
+    return a - b;
+  }
+
+  function add(uint256 a, uint256 b) internal pure returns (uint256) {
+    uint256 c = a + b;
+    require(c >= a);
+    return c;
+  }
+}

--- a/helpers/test-token-deployer/contracts/token/BasicToken.sol
+++ b/helpers/test-token-deployer/contracts/token/BasicToken.sol
@@ -1,0 +1,44 @@
+pragma solidity ^0.4.11;
+
+
+import './ERC20Basic.sol';
+import '../math/SafeMath.sol';
+
+
+/**
+ * @title Basic token
+ * @dev Basic version of StandardToken, with no allowances.
+ */
+contract BasicToken is ERC20Basic {
+  using SafeMath for uint256;
+  uint256 totalSupply_;
+
+  mapping(address => uint256) balances;
+
+  function totalSupply() public view returns (uint256) { return totalSupply_; }
+  /**
+  * @dev transfer token for a specified address
+  * @param _to The address to transfer to.
+  * @param _value The amount to be transferred.
+  */
+  function transfer(address _to, uint256 _value) public returns (bool) {
+    require(_to != address(0));
+    require(_value <= balances[msg.sender]);
+
+    // SafeMath.sub will throw if there is not enough balance.
+    balances[msg.sender] = balances[msg.sender].sub(_value);
+    balances[_to] = balances[_to].add(_value);
+    Transfer(msg.sender, _to, _value);
+    return true;
+  }
+
+  /**
+  * @dev Gets the balance of the specified address.
+  * @param _owner The address to query the the balance of.
+  * @return An uint256 representing the amount owned by the passed address.
+  */
+  function balanceOf(address _owner) public constant returns (uint256 balance) {
+    return balances[_owner];
+  }
+
+}

--- a/helpers/test-token-deployer/contracts/token/ERC20.sol
+++ b/helpers/test-token-deployer/contracts/token/ERC20.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.4.11;
+
+
+import './ERC20Basic.sol';
+
+
+/**
+ * @title ERC20 interface
+ * @dev see https://github.com/ethereum/EIPs/issues/20
+ */
+contract ERC20 is ERC20Basic {
+  function allowance(address owner, address spender) public constant returns (uint256);
+  function transferFrom(address from, address to, uint256 value) public returns (bool);
+  function approve(address spender, uint256 value) public returns (bool);
+  event Approval(address indexed owner, address indexed spender, uint256 value);
+}

--- a/helpers/test-token-deployer/contracts/token/ERC20Basic.sol
+++ b/helpers/test-token-deployer/contracts/token/ERC20Basic.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.4.11;
+
+
+/**
+ * @title ERC20Basic
+ * @dev Simpler version of ERC20 interface
+ * @dev see https://github.com/ethereum/EIPs/issues/179
+ */
+contract ERC20Basic {
+  function totalSupply() public view returns (uint256);
+  function balanceOf(address who) public constant returns (uint256);
+  function transfer(address to, uint256 value) public returns (bool);
+  event Transfer(address indexed from, address indexed to, uint256 value);
+}

--- a/helpers/test-token-deployer/contracts/token/StandardToken.sol
+++ b/helpers/test-token-deployer/contracts/token/StandardToken.sol
@@ -1,0 +1,87 @@
+pragma solidity ^0.4.11;
+
+
+import './BasicToken.sol';
+import './ERC20.sol';
+
+
+/**
+ * @title Standard ERC20 token
+ *
+ * @dev Implementation of the basic standard token.
+ * @dev https://github.com/ethereum/EIPs/issues/20
+ * @dev Based on code by FirstBlood: https://github.com/Firstbloodio/token/blob/master/smart_contract/FirstBloodToken.sol
+ */
+contract StandardToken is ERC20, BasicToken {
+
+  mapping (address => mapping (address => uint256)) internal allowed;
+
+
+  /**
+   * @dev Transfer tokens from one address to another
+   * @param _from address The address which you want to send tokens from
+   * @param _to address The address which you want to transfer to
+   * @param _value uint256 the amount of tokens to be transferred
+   */
+  function transferFrom(address _from, address _to, uint256 _value) public returns (bool) {
+    require(_to != address(0));
+    require(_value <= balances[_from]);
+    require(_value <= allowed[_from][msg.sender]);
+
+    balances[_from] = balances[_from].sub(_value);
+    balances[_to] = balances[_to].add(_value);
+    allowed[_from][msg.sender] = allowed[_from][msg.sender].sub(_value);
+    Transfer(_from, _to, _value);
+    return true;
+  }
+
+  /**
+   * @dev Approve the passed address to spend the specified amount of tokens on behalf of msg.sender.
+   *
+   * Beware that changing an allowance with this method brings the risk that someone may use both the old
+   * and the new allowance by unfortunate transaction ordering. One possible solution to mitigate this
+   * race condition is to first reduce the spender's allowance to 0 and set the desired value afterwards:
+   * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+   * @param _spender The address which will spend the funds.
+   * @param _value The amount of tokens to be spent.
+   */
+  function approve(address _spender, uint256 _value) public returns (bool) {
+    allowed[msg.sender][_spender] = _value;
+    Approval(msg.sender, _spender, _value);
+    return true;
+  }
+
+  /**
+   * @dev Function to check the amount of tokens that an owner allowed to a spender.
+   * @param _owner address The address which owns the funds.
+   * @param _spender address The address which will spend the funds.
+   * @return A uint256 specifying the amount of tokens still available for the spender.
+   */
+  function allowance(address _owner, address _spender) public constant returns (uint256 remaining) {
+    return allowed[_owner][_spender];
+  }
+
+  /**
+   * approve should be called when allowed[_spender] == 0. To increment
+   * allowed value is better to use this function to avoid 2 calls (and wait until
+   * the first transaction is mined)
+   * From MonolithDAO Token.sol
+   */
+  function increaseApproval (address _spender, uint _addedValue) public returns (bool success) {
+    allowed[msg.sender][_spender] = allowed[msg.sender][_spender].add(_addedValue);
+    Approval(msg.sender, _spender, allowed[msg.sender][_spender]);
+    return true;
+  }
+
+  function decreaseApproval (address _spender, uint _subtractedValue) public returns (bool success) {
+    uint oldValue = allowed[msg.sender][_spender];
+    if (_subtractedValue > oldValue) {
+      allowed[msg.sender][_spender] = 0;
+    } else {
+      allowed[msg.sender][_spender] = oldValue.sub(_subtractedValue);
+    }
+    Approval(msg.sender, _spender, allowed[msg.sender][_spender]);
+    return true;
+  }
+
+}

--- a/helpers/test-token-deployer/package.json
+++ b/helpers/test-token-deployer/package.json
@@ -14,8 +14,5 @@
   "devDependencies": {
     "truffle": "4.0.5",
     "truffle-hdwallet-provider": "0.0.3"
-  },
-  "dependencies": {
-    "@aragon/apps-finance": ">1.0.0"
   }
 }

--- a/helpers/test-token-deployer/package.json
+++ b/helpers/test-token-deployer/package.json
@@ -16,7 +16,6 @@
     "truffle-hdwallet-provider": "0.0.3"
   },
   "dependencies": {
-    "@aragon/apps-finance": "^1.0.1",
-    "@aragon/apps-vault": "^2.0.1"
+    "@aragon/apps-finance": ">1.0.0"
   }
 }

--- a/helpers/test-token-deployer/readme.md
+++ b/helpers/test-token-deployer/readme.md
@@ -1,6 +1,8 @@
 # Tokens template
 
-Used for creating test tokens in test networks.
+**Note**: the contracts in this package are unmaintained and should not be used for real token deployments!
+
+Used for creating test tokens in test networks (testnet Aragon organizations are still using these fake tokens).
 
 A Factory can mint unlimited tokens of any of its created tokens.
 

--- a/helpers/test-token-deployer/truffle.js
+++ b/helpers/test-token-deployer/truffle.js
@@ -1,6 +1,16 @@
-let x = require("@aragon/os/truffle-config")
-
-x.networks.rinkeby.gasPrice = 25000000001
-x.networks.rinkeby.gasLimit = 7e6
-
-module.exports = x
+module.exports = {
+  networks: {
+    rpc: {
+      network_id: 15,
+      host: 'localhost',
+      port: 8545,
+      gas: 6.9e6,
+      gasPrice: 15000000001
+    },
+    rinkeby: {
+      network_id: 4,
+      gas: 6.9e6,
+      gasPrice: 25000000001
+    },
+  },
+}


### PR DESCRIPTION
This package, outside of the list of token addresses held in its `index.js`, should be considered unmaintained (e.g. any contracts are not expected to compile or be deployable).

Reducing some of the dependencies results in a faster install time for this package's dependencies (e.g. aragon/aragon and some of the apps).