### PR TITLE
Chore: Use travis wait to install dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,7 @@ matrix:
   allow_failures:
     - env: TASK=test:agp1
   fast_finish: true
+install:
+  - travis_wait 20 npm install 
 script:
   - travis_wait 60 npm run $TASK


### PR DESCRIPTION
We were facing some issues while installing dependencies  in the CI due to timeouts