### PR TITLE
Fix scripts error handling

### DIFF
--- a/kits/beta-base/scripts/deploy_deps.js
+++ b/kits/beta-base/scripts/deploy_deps.js
@@ -17,6 +17,11 @@ const newRepo = async (apm, name, acc, contract) => {
   return await apm.newRepoWithVersion(name, acc, [1, 0, 0], c.address, '0x1245')
 }
 
+const errorOut = (msg) => {
+  console.error(msg)
+  throw new Error(msg)
+}
+
 const owner = process.env.OWNER
 
 module.exports = async (callback) => {

--- a/kits/beta-base/scripts/deploy_kit.js
+++ b/kits/beta-base/scripts/deploy_kit.js
@@ -17,6 +17,11 @@ const defaultENSAddress = process.env.ENS
 const defaultDAOFactoryAddress = process.env.DAO_FACTORY
 const defaultMinimeTokenFactoryAddress = process.env.MINIME_TOKEN_FACTORY
 
+const errorOut = (msg) => {
+  console.error(msg)
+  throw new Error(msg)
+}
+
 module.exports = async (
   truffleExecCallback,
   {

--- a/kits/democracy/scripts/democracy-deploy.js
+++ b/kits/democracy/scripts/democracy-deploy.js
@@ -1,17 +1,22 @@
 const deployKit = require('@aragon/kits-beta-base/scripts/deploy_kit.js')
 
-// Make sure that you have deployed ENS and APM and that you set the first one
-// in `ENS` env variable
-module.exports = async (callback) => {
+// Make sure that you have deployed ENS and APM and that you set the first one in `ENS` env variable
+
+async function deploy() {
+  const network = process.argv[process.argv.findIndex(arg => arg === '--network') + 1]
+
   const deployConfig = {
     artifacts,
+    network,
     kitName: 'democracy-kit',
     kitContractName: 'DemocracyKit',
     returnKit: true,
   }
 
   const { address } = await deployKit(null, deployConfig)
-
   console.log(address)
-  callback()
+}
+
+module.exports = callback => {
+  deploy().then(() => callback()).catch(err => callback(err))
 }

--- a/kits/democracy/scripts/deploy.js
+++ b/kits/democracy/scripts/deploy.js
@@ -4,7 +4,12 @@ const deploy_apm = require('@aragon/os/scripts/deploy-apm.js')
 const deploy_id = require('@aragon/id/scripts/deploy-beta-aragonid.js')
 const deploy_kit = require('@aragon/kits-beta-base/scripts/deploy_kit.js')
 
-module.exports = async (callback) => {
+const errorOut = (msg) => {
+  console.error(msg)
+  throw new Error(msg)
+}
+
+async function deploy() {
   console.log(`Deploying Democracy Kit, Owner ${process.env.OWNER}`)
 
   if (process.argv.length < 5) {
@@ -22,5 +27,9 @@ module.exports = async (callback) => {
   // aragonID
   await deploy_id(null, { artifacts, web3, ensAddress: ens.address })
 
-  await deploy_kit(null, { artifacts, kitName: 'democracy-kit', kitContractName: 'DemocracyKit', network: network, ensAddress: ens.address })
+  await deploy_kit(null, { artifacts, kitName: 'democracy-akropolis', kitContractName: 'DemocracyKit', network: network, ensAddress: ens.address })
+}
+
+module.exports = callback => {
+  deploy().then(() => callback()).catch(err => callback(err))
 }

--- a/kits/multisig/scripts/deploy.js
+++ b/kits/multisig/scripts/deploy.js
@@ -4,7 +4,12 @@ const deploy_apm = require('@aragon/os/scripts/deploy-apm.js')
 const deploy_id = require('@aragon/id/scripts/deploy-beta-aragonid.js')
 const deploy_kit = require('@aragon/kits-beta-base/scripts/deploy_kit.js')
 
-module.exports = async (callback) => {
+const errorOut = (msg) => {
+  console.error(msg)
+  throw new Error(msg)
+}
+
+async function deploy() {
   console.log(`Deploying Multisig Kit, Owner ${process.env.OWNER}`)
 
   if (process.argv.length < 5) {
@@ -23,4 +28,8 @@ module.exports = async (callback) => {
   await deploy_id(null, { artifacts, web3, ensAddress: ens.address })
 
   await deploy_kit(null, { artifacts, kitName: 'multisig-kit', kitContractName: 'MultisigKit', network: network, ensAddress: ens.address })
+}
+
+module.exports = callback => {
+  deploy().then(() => callback()).catch(err => callback(err))
 }

--- a/kits/multisig/scripts/multisig-deploy.js
+++ b/kits/multisig/scripts/multisig-deploy.js
@@ -1,17 +1,22 @@
 const deployKit = require('@aragon/kits-beta-base/scripts/deploy_kit.js')
 
-// Make sure that you have deployed ENS and APM and that you set the first one
-// in `ENS` env variable
-module.exports = async (callback) => {
+// Make sure that you have deployed ENS and APM and that you set the first one in `ENS` env variable
+
+async function deploy() {
+  const network = process.argv[process.argv.findIndex(arg => arg === '--network' || arg === '--environment') + 1]
+
   const deployConfig = {
     artifacts,
+    network,
     kitName: 'multisig-kit',
     kitContractName: 'MultisigKit',
     returnKit: true,
   }
 
   const { address } = await deployKit(null, deployConfig)
-
   console.log(address)
-  callback()
+}
+
+module.exports = callback => {
+  deploy().then(() => callback()).catch(err => callback(err))
 }


### PR DESCRIPTION
As we've been saying before, we do need to refactor these deployment scripts, there's code duplicated and it is not working flawless. This PR does not solve that at all, just tweaking it to at least not swallow thrown errors. 

I'm not aware of how the CLI interacts with these scripts, or if it expects them to behave in certain way. Note that I'm changing the way the truffle exec callback is handled in the scripts. 